### PR TITLE
feat(auth-token): add bearer token auth to receiver

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -27,15 +28,32 @@ type Payload struct {
 
 func main() {
 	addr := getEnv("ADDR", defaultAddr)
-
 	n := notifier.NewFromEnv()
 	notifier.RegisterMetrics()
+
 	http.Handle("/metrics", promhttp.Handler())
-	http.HandleFunc("/sync", loggingMiddleware(syncHandler(n)))
+	http.HandleFunc("/sync", loggingMiddleware(withAuth(syncHandler(n))))
 
 	log.Printf("🌐 Webhook receiver listening on %s...", addr)
 	if err := http.ListenAndServe(addr, nil); err != nil {
 		log.Fatalf("❌ Server failed: %v", err)
+	}
+}
+
+func withAuth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		expectedToken := os.Getenv("AUTH_TOKEN")
+		if expectedToken == "" {
+			next(w, r)
+			return
+		}
+
+		auth := r.Header.Get("Authorization")
+		if !strings.HasPrefix(auth, "Bearer ") || strings.TrimPrefix(auth, "Bearer ") != expectedToken {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next(w, r)
 	}
 }
 


### PR DESCRIPTION
# 📦 Changelog

## [v1.0.0] - 2025-04-18

🎉 **Initial production-ready release**

### 🚀 Features
- CLI `argocd-sync` written in Go with Cobra
- Webhook Receiver service with Prometheus `/metrics`
- Slack and Telegram notifications with rich formatting
- Full Helm Chart for Kubernetes deployment
- Dockerfiles (distroless, secure, non-root)
- Grafana dashboard via ConfigMap
- CI/CD integration examples (GitHub, GitLab, Bitbucket, Jenkins, CircleCI)
- MkDocs documentation site with Material theme

### 🔐 Security
- Auth via `Bearer Token` in `/sync` endpoint
- Secrets handled via ENV or Kubernetes Secrets
- JSON request validation for safety
- Non-root distroless images

### 📈 Observability
- Prometheus metrics: `sync_total`, `sync_duration`
- Grafana dashboard for sync monitoring
- Custom labels: `app`, `status`, `duration`

### 🧪 Tooling
- `Makefile` with build, lint, scan, docker
- `docker-compose.yml` for local Prometheus + Receiver
- Test scripts in Go and Python

---

Looking for older releases? Stay tuned for versioned tags and [[GitHub Releases](https://github.com/giovanni-gava/argocd-pipeline-trigger/releases)](https://github.com/giovanni-gava/argocd-pipeline-trigger/releases).

Want to contribute? Check out [[CONTRIBUTING.md](https://chatgpt.com/g/g-p-67eaaf1118cc81919d3a5e00b1b70848-github/c/CONTRIBUTING.md)](./CONTRIBUTING.md).